### PR TITLE
remove default base url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var Q = require('q');
 var async = require('async');
 
 var DEFAULT_LIMIT = 500;
+var SPRINTLY_URL = 'https://sprint.ly/';
 
 var presentResponses = function(jsonStrings) {
   return _.flatten(
@@ -12,6 +13,8 @@ var presentResponses = function(jsonStrings) {
 };
 
 var getOpts = function (searchQuery, options) {
+  options = _.defaults(options, {baseUrl: SPRINTLY_URL});
+
   var baseUrl = options.baseUrl;
   var opts = {
     json: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ var Q = require('q');
 var async = require('async');
 
 var DEFAULT_LIMIT = 500;
-var SPRINTLY_URL = 'https://sprint.ly/';
 
 var presentResponses = function(jsonStrings) {
   return _.flatten(
@@ -13,7 +12,7 @@ var presentResponses = function(jsonStrings) {
 };
 
 var getOpts = function (searchQuery, options) {
-  var baseUrl = options.baseUrl || SPRINTLY_URL;
+  var baseUrl = options.baseUrl;
   var opts = {
     json: true,
     url: baseUrl + '/api/items/search.json',


### PR DESCRIPTION
Remove default url: we want the ability to pass in an empty string for base_url for dev and staging environments. This also contains an extra '/', so the result is '...sprint.ly//api.....'. 
