### PR TITLE
Support for OAuth clients

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,12 +23,20 @@ var getOpts = function (searchQuery, options) {
       q: searchQuery,
       limit: options.limit || DEFAULT_LIMIT
     },
-    auth: {
-      username: options.user,
-      password: options.pass
-    },
     debug: !!options.debug
   };
+
+  if (options.token) {
+    opts.headers = {
+      'Authorization': 'Bearer ' + options.token
+    };
+  } else if (options.user && options.pass) {
+    opts.auth = {
+      username: options.user,
+      password: options.pass
+    };
+  }
+
   return opts;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var Q = require('q');
 var async = require('async');
 
 var DEFAULT_LIMIT = 500;
-var SPRINTLY_URL = 'https://sprint.ly/';
+var SPRINTLY_URL = 'https://local.sprint.ly:9000/';
 
 var presentResponses = function(jsonStrings) {
   return _.flatten(
@@ -27,8 +27,8 @@ var getOpts = function (searchQuery, options) {
   };
 
   if (options.token) {
-    opts.headers = {
-      'Authorization': 'Bearer ' + options.token
+    opts.auth = {
+      bearer: options.token
     };
   } else if (options.user && options.pass) {
     opts.auth = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var Q = require('q');
 var async = require('async');
 
 var DEFAULT_LIMIT = 500;
-var SPRINTLY_URL = 'https://local.sprint.ly:9000/';
+var SPRINTLY_URL = 'https://sprint.ly/';
 
 var presentResponses = function(jsonStrings) {
   return _.flatten(
@@ -27,8 +27,8 @@ var getOpts = function (searchQuery, options) {
   };
 
   if (options.token) {
-    opts.auth = {
-      bearer: options.token
+    opts.headers = {
+      'Authorization': 'Bearer ' + options.token
     };
   } else if (options.user && options.pass) {
     opts.auth = {

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -187,7 +187,7 @@ describe('getOptions', function() {
       token: 'abc123'
     });
 
-    assert.equal(opts.headers.Authorization, 'Bearer abc123');
+    assert.equal(opts.auth.bearer, 'abc123');
   });
 
   it('adds basic auth if user and password present', function() {

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -187,7 +187,7 @@ describe('getOptions', function() {
       token: 'abc123'
     });
 
-    assert.equal(opts.auth.bearer, 'abc123');
+    assert.equal(opts.headers.Authorization, 'Bearer abc123');
   });
 
   it('adds basic auth if user and password present', function() {

--- a/lib/index_test.js
+++ b/lib/index_test.js
@@ -181,3 +181,21 @@ describe('search', function () {
   });
 });
 
+describe('getOptions', function() {
+  it('adds bearer auth to headers if token present', function() {
+    var opts = API.getOptions('foo', {
+      token: 'abc123'
+    });
+
+    assert.equal(opts.headers.Authorization, 'Bearer abc123');
+  });
+
+  it('adds basic auth if user and password present', function() {
+    var opts = API.getOptions('foo', {
+      user: 'test',
+      pass: 'passes'
+    });
+
+    assert.deepEqual(opts.auth, { username: 'test', password: 'passes' });
+  });
+});


### PR DESCRIPTION
#### What does it do?

Adds support for a bearer token in lieu of a username and api key. This lets Oauth clients use sprintly search!
#### Where should the reviewer start?

`lib/index.js` and tests
#### How should this be manually tested?

Checkout [5columns#search](https://github.com/sprintly/5columns/tree/search) or otherwise pass a valid token to the client and perform a search.
#### GIF?

![vwd5ud2](https://cloud.githubusercontent.com/assets/84644/7015043/43b7edea-dc82-11e4-865d-30414f4f5781.gif)
#### Does this require a version bump
- [x] Yes
  - [ ] MAJOR
  - [x] MINOR
  - [ ] PATCH
